### PR TITLE
Support for tablenames containing periods

### DIFF
--- a/src/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Database/Eloquent/Relations/HasOneOrMany.php
@@ -22,8 +22,13 @@ abstract class HasOneOrMany extends BaseHasOneOrMany
             //If the foreign key is an array (multi-column relationship), we adjust the query.
             if(is_array($this->foreignKey)) {
                 foreach ($this->foreignKey as $index => $key){
-                    list(, $key) = explode('.', $key);
-                    $fullKey = $this->getRelated()->getTable() . '.' . $key;
+
+                    $keyPortions = explode('.', $key);
+                    if(count($keyPortions) === 2)
+                        $fullKey = $this->getRelated()->getTable() . '.' . $key;
+                    else
+                        $fullKey = $key;
+
                     $this->query->where($fullKey, '=', $parentKeyValue[$index]);
                     $this->query->whereNotNull($fullKey);
                 }


### PR DESCRIPTION
Unable to create a supporting test case as SQLite, used by the tests, does not have support for multiple databases. Fix for #13.