### PR TITLE
extends from HasOne / HasMany instead of HasOneOrMany

### DIFF
--- a/src/Database/Eloquent/Relations/HasMany.php
+++ b/src/Database/Eloquent/Relations/HasMany.php
@@ -3,8 +3,9 @@
 namespace Awobaz\Compoships\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\HasOne as BaseHasOne;
 
-class HasMany extends HasOneOrMany
+class HasMany extends BaseHasOne
 {
     /**
      * Get the results of the relationship.

--- a/src/Database/Eloquent/Relations/HasOne.php
+++ b/src/Database/Eloquent/Relations/HasOne.php
@@ -5,8 +5,9 @@ namespace Awobaz\Compoships\Database\Eloquent\Relations;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
+use Illuminate\Database\Eloquent\Relations\HasMany as BaseHasMany;
 
-class HasOne extends HasOneOrMany
+class HasOne extends BaseHasMany
 {
     use SupportsDefaultModels;
 


### PR DESCRIPTION
This is important, when you working with interfaces which use HasOne / HasMany as return type.