### PR TITLE
Fix relationships phpdoc type hints

### DIFF
--- a/src/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Database/Eloquent/Concerns/HasRelationships.php
@@ -36,8 +36,8 @@ trait HasRelationships
      * Define a one-to-one relationship.
      *
      * @param  string $related
-     * @param  string $foreignKey
-     * @param  string $localKey
+     * @param  string|array|null $foreignKey
+     * @param  string|array|null $localKey
      * @return \Awobaz\Compoships\Database\Eloquent\Relations\HasOne
      */
     public function hasOne($related, $foreignKey = null, $localKey = null)
@@ -81,8 +81,8 @@ trait HasRelationships
      * Define a one-to-many relationship.
      *
      * @param  string $related
-     * @param  string $foreignKey
-     * @param  string $localKey
+     * @param  string|array|null $foreignKey
+     * @param  string|array|null $localKey
      * @return \Awobaz\Compoships\Database\Eloquent\Relations\HasMany
      */
     public function hasMany($related, $foreignKey = null, $localKey = null)
@@ -110,8 +110,8 @@ trait HasRelationships
      * Define an inverse one-to-one or many relationship.
      *
      * @param  string $related
-     * @param  string $foreignKey
-     * @param  string $ownerKey
+     * @param  string|array|null $foreignKey
+     * @param  string|array|null $ownerKey
      * @param  string $relation
      * @return \Awobaz\Compoships\Database\Eloquent\Relations\BelongsTo
      */


### PR DESCRIPTION
The relationship methods' phpdoc type hints do not reflect the actual
values that can be passed on to the methods. Using a static code
analyser like LArastan gives a lot of false positives because of to
this.
