### PR TITLE
Lets honor DB::raw expressions 

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,7 +25,7 @@ abstract class TestCase extends BaseTestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
Lets honor DB::raw expressions as model keys in both single and array format. I encounter this problem because one if DB columns named 'p.0' would auto converted to string in `Concerns/HasRelationships.php` which caused fatal errors.