### PR TITLE
fix: php fatal array to string conversion

### DIFF
--- a/src/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Database/Eloquent/Concerns/HasRelationships.php
@@ -57,11 +57,11 @@ trait HasRelationships
             foreach ($foreignKey as $key) {
                 $foreignKeys[] = $this->maybeExpression($instance, $key);
             }
+        } else {
+            $foreignKey = $this->maybeExpression($instance, $foreignKey);
         }
 
         $localKey = $localKey ?: $this->getKeyName();
-
-        $foreignKey = $this->maybeExpression($instance, $foreignKey);
 
         return new HasOne($instance->newQuery(), $this, $foreignKeys ?: $foreignKey, $localKey);
     }


### PR DESCRIPTION
In my previous commit I have not tested hasOne relationship on compound key as result I missed the case. Such relationship is causing php fatal 'array to string conversion'.