### PR TITLE
Perf: Use parent implemention for non-composite keys

### DIFF
--- a/src/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Database/Eloquent/Relations/BelongsTo.php
@@ -45,7 +45,7 @@ class BelongsTo extends BaseBelongsTo
                     }
                 }
             } else {
-                $this->query->where($table.'.'.$this->ownerKey, '=', $this->child->{$this->foreignKey});
+                parent::addConstraints();
             }
         }
     }
@@ -67,11 +67,7 @@ class BelongsTo extends BaseBelongsTo
 
             $this->query->whereIn($keys, $this->getEagerModelKeys($models));
         } else {
-            // We'll grab the primary key name of the related models since it could be set to
-            // a non-standard name and not "id". We will then construct the constraint for
-            // our eagerly loading query so it returns the proper models from execution.
-            $key = $this->related->getTable().'.'.$this->ownerKey;
-            $this->query->whereIn($key, $this->getEagerModelKeys($models));
+            parent::addEagerConstraints($models);
         }
     }
 

--- a/src/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Database/Eloquent/Relations/HasOneOrMany.php
@@ -29,23 +29,9 @@ trait HasOneOrMany
                     $this->query->whereNotNull($fullKey);
                 }
             } else {
-                $fullKey = $this->getRelated()
-                        ->getTable().'.'.$foreignKey;
-                $this->query->where($fullKey, '=', $parentKeyValue);
-                $this->query->whereNotNull($fullKey);
+                parent::addConstraints();
             }
         }
-    }
-
-    /**
-     * Set the constraints for an eager load of the relation.
-     *
-     * @param  array  $models
-     * @return void
-     */
-    public function addEagerConstraints(array $models)
-    {
-        $this->query->whereIn($this->foreignKey, $this->getKeys($models, $this->localKey));
     }
 
     /**


### PR DESCRIPTION
Fixes #72.

From version 5.7 Laravel introduced eager loading optimization when `$keyType` is `"int"` or `"integer"`. Composite relation should also follow the optimization, however, it's a quite difficult to implement as well. So I improved that the original optimization can be applied when keys are not composite at least.
