### PR TITLE
Allow nullable columns

### DIFF
--- a/src/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Database/Eloquent/Relations/BelongsTo.php
@@ -39,9 +39,20 @@ class BelongsTo extends BaseBelongsTo
 
             if (is_array($this->ownerKey)) { //Check for multi-columns relationship
                 $childAttributes = $this->child->attributesToArray();
+
+                $allOwnerKeyValuesKeysAreNull = array_unique(array_values(
+                    array_intersect_key($childAttributes, array_flip($this->ownerKey))
+                )) === [null];
+
                 foreach ($this->ownerKey as $index => $key) {
+                    $fullKey = $table.'.'.$key;
+
                     if (array_key_exists($this->foreignKey[$index], $childAttributes)) {
-                        $this->query->where($table.'.'.$key, '=', $this->child->{$this->foreignKey[$index]});
+                        $this->query->where($fullKey, '=', $this->child->{$this->foreignKey[$index]});
+                    }
+
+                    if ($allOwnerKeyValuesKeysAreNull) {
+                        $this->query->whereNotNull($fullKey);
                     }
                 }
             } else {

--- a/src/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Database/Eloquent/Relations/HasOneOrMany.php
@@ -21,12 +21,17 @@ trait HasOneOrMany
 
             //If the foreign key is an array (multi-column relationship), we adjust the query.
             if (is_array($this->foreignKey)) {
+                $allParentKeyValuesAreNull = array_unique($parentKeyValue) === [null];
+
                 foreach ($this->foreignKey as $index => $key) {
                     list(, $key) = explode('.', $key);
                     $fullKey = $this->getRelated()
                             ->getTable().'.'.$key;
                     $this->query->where($fullKey, '=', $parentKeyValue[$index]);
-                    $this->query->whereNotNull($fullKey);
+
+                    if ($allParentKeyValuesAreNull) {
+                        $this->query->whereNotNull($fullKey);
+                    }
                 }
             } else {
                 parent::addConstraints();

--- a/tests/ComposhipsTest.php
+++ b/tests/ComposhipsTest.php
@@ -32,6 +32,7 @@ class ComposhipsTest extends TestCase
             ->save(new TrackingTask());
 
         $this->assertNotNull($allocation->trackingTasks);
+        $this->assertInstanceOf(Allocation::class, $allocation->trackingTasks->first()->allocation);
 
         Model::reguard();
     }

--- a/tests/ComposhipsTest.php
+++ b/tests/ComposhipsTest.php
@@ -33,7 +33,7 @@ class ComposhipsTest extends TestCase
 
         $this->assertNotNull($allocation->trackingTasks);
 
-        Model::unguard();
+        Model::reguard();
     }
 
     /**
@@ -55,7 +55,7 @@ class ComposhipsTest extends TestCase
 
         $this->assertNotNull($allocation->space);
 
-        Model::unguard();
+        Model::reguard();
     }
 
     /**
@@ -82,6 +82,9 @@ class ComposhipsTest extends TestCase
         $this->assertNotNull($allocation->trackingTasks);
         $this->assertEquals($allocation->trackingTasks->count(), 3);
         $this->assertInstanceOf(Allocation::class, $allocation->trackingTasks->first()->allocation);
+
+        Model::reguard();
+    }
 
     /**
      * Test the save method on a relationship with a null value
@@ -172,7 +175,7 @@ class ComposhipsTest extends TestCase
         $this->assertNotNull($allocation->trackingTasks);
         $this->assertInstanceOf(Allocation::class, $allocation->trackingTasks->first()->allocation);
 
-        Model::unguard();
+        Model::reguard();
     }
 
     /**
@@ -200,7 +203,7 @@ class ComposhipsTest extends TestCase
         $this->assertNotNull($trackingTask);
         $this->assertInstanceOf(Allocation::class, $trackingTask->allocation);
 
-        Model::unguard();
+        Model::reguard();
     }
 
     public function testHas()
@@ -261,7 +264,7 @@ class ComposhipsTest extends TestCase
 
         $this->assertNotNull($pickupPoint->pickupTimes);
 
-        Model::unguard();
+        Model::reguard();
     }
 
     public function testFactories()

--- a/tests/ComposhipsTest.php
+++ b/tests/ComposhipsTest.php
@@ -6,6 +6,7 @@ use Awobaz\Compoships\Tests\Model\PickupPoint;
 use Awobaz\Compoships\Tests\Model\PickupTime;
 use Awobaz\Compoships\Tests\Model\Space;
 use Awobaz\Compoships\Tests\Model\TrackingTask;
+use Awobaz\Compoships\Tests\Model\User;
 use Faker\Generator as Faker;
 use Illuminate\Database\Eloquent\Factory;
 
@@ -82,7 +83,73 @@ class ComposhipsTest extends TestCase
         $this->assertEquals($allocation->trackingTasks->count(), 3);
         $this->assertInstanceOf(Allocation::class, $allocation->trackingTasks->first()->allocation);
 
+    /**
+     * Test the save method on a relationship with a null value
+     *
+     * @return void
+     */
+    public function testSaveWithANullValue()
+    {
         Model::unguard();
+
+        $allocation = new Allocation();
+        $allocation->booking_id = 1;
+        $allocation->vehicle_id = null;
+        $allocation->save();
+
+        $allocation->trackingTasks()
+            ->save(new TrackingTask());
+
+        $this->assertNotNull($allocation->trackingTasks);
+        $this->assertTrue($allocation->trackingTasks->isNotEmpty());
+        $this->assertInstanceOf(Allocation::class, $allocation->trackingTasks->first()->allocation);
+
+        Model::reguard();
+    }
+
+    /**
+     * Test a relationship with only null values is not supported
+     *
+     * @return void
+     */
+    public function testARelationshipWithOnlyNullValuesIsNotSupported()
+    {
+        Model::unguard();
+
+        $allocation = new Allocation();
+        $allocation->booking_id = null;
+        $allocation->vehicle_id = null;
+        $allocation->save();
+
+        $allocation->trackingTasks()
+            ->save(new TrackingTask());
+
+        $this->assertNotNull($allocation->trackingTasks);
+        $this->assertTrue($allocation->trackingTasks->isEmpty());
+        $this->assertNull(TrackingTask::first()->allocation);
+
+        Model::reguard();
+    }
+
+    /**
+     * Test a relationship with a foreign key is empty on a new instance
+     *
+     * @return void
+     */
+    public function testARelationshipWithAForeignKeyIsEmptyOnANewInstance()
+    {
+        Model::unguard();
+
+        $allocation = new Allocation();
+        $allocation->user_id = null;
+        $allocation->save();
+
+        $user = new User();
+
+        $this->assertNotNull($user->allocations);
+        $this->assertTrue($user->allocations->isEmpty());
+
+        Model::reguard();
     }
 
     /**

--- a/tests/Models/Allocation.php
+++ b/tests/Models/Allocation.php
@@ -15,4 +15,9 @@ class Allocation extends Model
     {
         return $this->hasOne(Space::class, 'booking_id', 'booking_id');
     }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, ['user_id', 'booking_id'], ['id', 'booking_id']);
+    }
 }

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Awobaz\Compoships\Tests\Model;
+
+use Awobaz\Compoships\Database\Eloquent\Model;
+
+class User extends Model
+{
+    public function allocations()
+    {
+        return $this->hasMany(Allocation::class, ['user_id', 'booking_id'], ['id', 'booking_id']);
+    }
+}

--- a/tests/migrations.php
+++ b/tests/migrations.php
@@ -15,10 +15,15 @@ class Migration extends BaseMigration
     {
         Schema::create('allocations', function (Blueprint $table) {
             $table->increments('id');
+            $table->integer('user_id')
+                ->unsigned()
+                ->nullable();
             $table->integer('booking_id')
-                ->unsigned();
+                ->unsigned()
+                ->nullable();
             $table->integer('vehicle_id')
-                ->unsigned();
+                ->unsigned()
+                ->nullable();
             $table->timestamps();
         });
 
@@ -32,9 +37,11 @@ class Migration extends BaseMigration
         Schema::create('tracking_tasks', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('booking_id')
-                ->unsigned();
+                ->unsigned()
+                ->nullable();
             $table->integer('vehicle_id')
-                ->unsigned();
+                ->unsigned()
+                ->nullable();
 
             $table->foreign('booking_id')
                 ->references('booking_id')
@@ -73,6 +80,14 @@ class Migration extends BaseMigration
                 ->onUpdate('cascade')
                 ->onDelete('cascade');
 
+            $table->timestamps();
+        });
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('booking_id')
+                ->unsigned()
+                ->nullable();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
Please see #80.

I created a new User model in tests in order to have a real foreign key, so that I could test the usefulness of this line ``$this->query->whereNotNull($fullKey);`` in _HasOneOrMany_ (see testARelationshipWithAForeignKeyIsEmptyOnANewInstance).

I also ended up locking down the belongsTo relationship with only null values. in order to have a consistent behaviour with the opposite hasMany (see testARelationshipWithOnlyNullValuesIsNotSupported). Not sure about that though, let me know what you think.

Any comment or suggestion appreciated!