### PR TITLE
Fixed issue #85

### DIFF
--- a/src/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Database/Eloquent/Relations/HasOneOrMany.php
@@ -24,7 +24,8 @@ trait HasOneOrMany
                 $allParentKeyValuesAreNull = array_unique($parentKeyValue) === [null];
 
                 foreach ($this->foreignKey as $index => $key) {
-                    list(, $key) = explode('.', $key);
+                    $tmp = explode('.', $key);
+                    $key = end($tmp);
                     $fullKey = $this->getRelated()
                             ->getTable().'.'.$key;
                     $this->query->where($fullKey, '=', $parentKeyValue[$index]);


### PR DESCRIPTION
The problem occurs, if the table name of the model contains a database name. (See Issue #85)

Like:
`protected $table = 'ctd.item';`