### PR TITLE
enforce UTC timezone for tests due to behavior changes in Laravel 7

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,3 +12,6 @@ if (PHP_MAJOR_VERSION === 7 && in_array(PHP_MINOR_VERSION, [0, 1])) {
 $autoloader->addClassMap([
     \Awobaz\Compoships\Tests\TestCase\TestCase::class => $mappedTestCaseFilename,
 ]);
+
+// NOTE: we enforce UTC timezone because since Laravel 7 it has changed behavior for datetime casting (it includes timezone)
+date_default_timezone_set('UTC');


### PR DESCRIPTION
Some recent changes to Laravel 7 broke behavior to datetime casting. As we don't care about it and just want to check if field was set I enforce UTC timezone, so tests can pass