### PR TITLE
Let raw expresions be foreign keys

### DIFF
--- a/src/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Database/Eloquent/Concerns/HasRelationships.php
@@ -220,7 +220,7 @@ trait HasRelationships
             ->getQueryGrammar();
 
         return $grammar->isExpression($foreignKey)
-            ? DB::raw($instance->getTable().'.'.$foreignKey)
+            ? $foreignKey
             : $instance->getTable().'.'.$foreignKey;
     }
 }


### PR DESCRIPTION
Closes #121
Let raw expresions be foreign keys

Example:
```php
use DB;
class A extends \Illuminate\Database\Eloquent\Model;
{
    use \Awobaz\Compoships\Compoships;
    
    public function b()
    {
        return $this->hasMany('B',
                ['foreignKey1', DB::raw('C.foreignKey2')], //can be more raws
                ['localKey1', 'localKey2']
            )
            ->join('C','C.other_key','=','B.other_key');
    }
}
```
Actual results:
```sql
(`B`.`foreignKey1`= 1 and B.C.foreignKey2 = 2)
```
Expected results:
```sql
(`B`.`foreignKey1`= 1 and C.foreignKey2 = 2)
```
---------
maybe we can have more options with `DB::raw()` example 
```php
$this->hasMany('B',
    ['foreignKey1', DB::raw("SUBSTRING(B.code, 1, 2)")],
    ['localKey1', 'localPrefix']
);
```
results on 
```sql
(`B`.`foreignKey1`= 1 and SUBSTRING(B.code, 1, 2) = 'US')
```
@topclaudy 