### PR TITLE
Fix README incorrect param name

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ class B extends Model
     
     public function a()
     {
-        return $this->belongsTo('A', ['foreignKey1', 'foreignKey2'], ['localKey1', 'localKey2']);
+        return $this->belongsTo('A', ['foreignKey1', 'foreignKey2'], ['ownerKey1', 'ownerKey2']);
     }
 }
 ```


### PR DESCRIPTION
I think that the 3rd param of `belongsTo` is `ownerKey` not `localKey` (according to [Laravel docs](https://laravel.com/docs/8.x/eloquent-relationships#one-to-many-inverse)).

If i get it wrong, you can close PR.

If PR is accepted and you don't mind, could you add a `hacktoberfest-accepted` label to help me with hacktoberfest? Thanks!