### PR TITLE
Adding function to support the new ofMany() function

### DIFF
--- a/src/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Database/Eloquent/Relations/HasOneOrMany.php
@@ -5,6 +5,7 @@ namespace Awobaz\Compoships\Database\Eloquent\Relations;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\JoinClause;
 
 trait HasOneOrMany
 {
@@ -259,6 +260,23 @@ trait HasOneOrMany
             }
         } else {
             parent::setForeignAttributesForCreate($model);
+        }
+    }
+
+    /**
+     * Add join query constraints for one of many relationships.
+     *
+     * @param  \Illuminate\Database\Eloquent\JoinClause  $join
+     * @return void
+     */
+    public function addOneOfManyJoinSubQueryConstraints(JoinClause $join)
+    {
+        if (is_array($this->foreignKey)) {
+            foreach ($this->foreignKey as $key) {
+                $join->on($this->qualifySubSelectColumn($key), '=', $this->qualifyRelatedColumn($key));
+            }
+        } else {
+            parent::addOneOfManyJoinSubQueryConstraints($join);
         }
     }
 }

--- a/src/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Database/Eloquent/Relations/HasOneOrMany.php
@@ -266,7 +266,7 @@ trait HasOneOrMany
     /**
      * Add join query constraints for one of many relationships.
      *
-     * @param  \Illuminate\Database\Eloquent\JoinClause  $join
+     * @param  \Illuminate\Database\Eloquent\JoinClause $join
      * @return void
      */
     public function addOneOfManyJoinSubQueryConstraints(JoinClause $join)

--- a/src/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Database/Eloquent/Relations/HasOneOrMany.php
@@ -267,6 +267,7 @@ trait HasOneOrMany
      * Add join query constraints for one of many relationships.
      *
      * @param  \Illuminate\Database\Eloquent\JoinClause $join
+     * 
      * @return void
      */
     public function addOneOfManyJoinSubQueryConstraints(JoinClause $join)

--- a/src/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Database/Eloquent/Relations/HasOneOrMany.php
@@ -266,8 +266,8 @@ trait HasOneOrMany
     /**
      * Add join query constraints for one of many relationships.
      *
-     * @param  \Illuminate\Database\Eloquent\JoinClause $join
-     * 
+     * @param \Illuminate\Database\Eloquent\JoinClause $join
+     *
      * @return void
      */
     public function addOneOfManyJoinSubQueryConstraints(JoinClause $join)


### PR DESCRIPTION
This PR adds support for ofMany(). See https://laravel-news.com/one-of-many-eloquent-relationship

```
public function latestAgentContact()
{
    return $this->hasOne(Contact::class, ['clientid', 'agentid'], ['id', 'agentid'])->ofMany(['contactdate' => 'max']);
}
```