### PR TITLE
docs: ✏️ Update PHPUnit installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ To run unit tests you have to obtain manually proper version of PHPUnit
 
 Example
 ```bash
-wget -O phpunit https://phar.phpunit.de/phpunit-8.phar
+curl -L -O https://phar.phpunit.de/phpunit-9.phar
+mv phpunit-9.phar phpunit
 chmod +x phpunit
 ./phpunit
 ```


### PR DESCRIPTION
The wget binary is not installed by default on many systems (such as macOS). curl on the other hand is.