### PR TITLE
Fix BelongsTo::associate() doc block

### DIFF
--- a/src/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Database/Eloquent/Relations/BelongsTo.php
@@ -28,7 +28,7 @@ class BelongsTo extends BaseBelongsTo
     /**
      * Associate the model instance to the given parent.
      *
-     * @param \Illuminate\Database\Eloquent\Model|int|string $model
+     * @param \Illuminate\Database\Eloquent\Model|int|string|null $model
      *
      * @return \Illuminate\Database\Eloquent\Model
      */


### PR DESCRIPTION
associate() should be able to access `null` as parameter


https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php#L201
https://github.com/laravel/framework/pull/39614/files