### PR TITLE
Add support for factory relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ class B extends Model
 }
 ```
 
+### Factories
+
+Chances are that you may need factories for your Compoships models. If so, you will provably need to use
+Factory methods to create relationship models. For example, by using the ->has() method. Just use the
+``Awobaz\Compoships\Database\Eloquent\Factories\ComposhipsFactory`` trait in your factory classes to be able
+to use relationships correctly.
+
 ### Example
 
 As an example, let's pretend we have a task list with categories, managed by several teams of users where:

--- a/src/Database/Eloquent/Factories/ComposhipsFactory.php
+++ b/src/Database/Eloquent/Factories/ComposhipsFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Awobaz\Compoships\Database\Eloquent\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory as EloquentFactory;
+
+trait ComposhipsFactory
+{
+    public function has(EloquentFactory $factory, $relationship = null)
+    {
+        return $this->newInstance([
+            'has' => $this->has->concat([new Relationship(
+                $factory, $relationship ?? $this->guessRelationship($factory->modelName())
+            )]),
+        ]);
+    }
+
+}

--- a/src/Database/Eloquent/Factories/Relationship.php
+++ b/src/Database/Eloquent/Factories/Relationship.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Awobaz\Compoships\Database\Eloquent\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Relationship as EloquentRelationship;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
+use Illuminate\Database\Eloquent\Relations\MorphOneOrMany;
+
+class Relationship extends EloquentRelationship
+{
+    public function createFor(Model $parent)
+    {
+        $relationship = $parent->{$this->relationship}();
+
+        if ($relationship instanceof MorphOneOrMany) {
+            $this->factory->state([
+                $relationship->getMorphType() => $relationship->getMorphClass(),
+                $relationship->getForeignKeyName() => $relationship->getParentKey(),
+            ])->create([], $parent);
+        } elseif ($relationship instanceof HasOneOrMany) { // This relationship is supported by Compoships. Check for multi-columns relationship.
+            $this->factory->state(is_array($relationship->getForeignKeyName()) ?
+                array_combine($relationship->getForeignKeyName(), $relationship->getParentKey()) :
+                [$relationship->getForeignKeyName() => $relationship->getParentKey()]
+            )->create([], $parent);
+        } elseif ($relationship instanceof BelongsToMany) {
+            $relationship->attach($this->factory->create([], $parent));
+        }
+    }
+}


### PR DESCRIPTION
Related to issue #154 

The idea of this PR is to add support for factory relationships. Right now methods such as ->has() or ->for() don't work for factories related to compoship models.

For the first version of this PR, I have added support for the ->has() method only. I have tested it locally and it works. I have tried to follow the same patterns of usage and files organization as the current package. Once we agree on that, and if we agree that this PR will be merged, we can work on the implementation for the other type of relationship allowed by this package that has a related method in the Factory class: the ->for() method. I left it for now because that's a little bit more tricky and I wanna make sure I do it only if the idea is merging this PR. I hope you understand ;)