### PR TITLE
Fixed crash when key contains BackedEnum

### DIFF
--- a/src/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Database/Eloquent/Relations/BelongsTo.php
@@ -234,7 +234,7 @@ class BelongsTo extends BaseBelongsTo
         foreach ($results as $result) {
             if (is_array($owner)) { //Check for multi-columns relationship
                 $dictKeyValues = array_map(function ($k) use ($result) {
-                    return $result->{$k};
+                    return $result->{$k} instanceof \BackedEnum ? $result->{$k}->value : $result->{$k};
                 }, $owner);
 
                 $dictionary[implode('-', $dictKeyValues)] = $result;
@@ -249,7 +249,7 @@ class BelongsTo extends BaseBelongsTo
         foreach ($models as $model) {
             if (is_array($foreign)) { //Check for multi-columns relationship
                 $dictKeyValues = array_map(function ($k) use ($model) {
-                    return $model->{$k};
+                    return $model->{$k} instanceof \BackedEnum ? $model->{$k}->value : $model->{$k};
                 }, $foreign);
 
                 $key = implode('-', $dictKeyValues);

--- a/tests/Enums/UserProfileType.php
+++ b/tests/Enums/UserProfileType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Awobaz\Compoships\Tests\Enums;
+
+enum UserProfileType: string
+{
+    case Email = 'email';
+    case Url = 'url';
+}

--- a/tests/Migration.php
+++ b/tests/Migration.php
@@ -116,5 +116,32 @@ class Migration extends BaseMigration
             $table->uuid('pcid')->unique();
             $table->string('code');
         });
+
+        Capsule::schema()->create('user_profiles', function (Blueprint $table) {
+            $table->integer('user_id')
+                ->unsigned();
+            $table->string('user_profile_type');
+            $table->timestamps();
+
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users')
+                ->onUpdate('cascade')
+                ->onDelete('cascade');
+        });
+
+        Capsule::schema()->create('user_profile_texts', function (Blueprint $table) {
+            $table->integer('user_id')
+                ->unsigned();
+            $table->string('user_profile_type');
+            $table->string('user_profile_text');
+            $table->timestamps();
+
+            $table->foreign(['user_id', 'user_profile_type'])
+                ->references(['user_id', 'user_profile_type'])
+                ->on('user_profiles')
+                ->onUpdate('cascade')
+                ->onDelete('cascade');
+        });
     }
 }

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -3,6 +3,7 @@
 namespace Awobaz\Compoships\Tests\Models;
 
 use Awobaz\Compoships\Compoships;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 
@@ -12,6 +13,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon $created_at
  * @property Carbon $updated_at
  * @property-read Allocation[] $allocations
+ * @property-read Collection<UserProfile> $userProfiles
  *
  * @mixin \Illuminate\Database\Eloquent\Builder
  */
@@ -28,5 +30,10 @@ class User extends Model
     public function allocations()
     {
         return $this->hasMany(Allocation::class, ['user_id', 'booking_id'], ['id', 'booking_id']);
+    }
+
+    public function userProfiles()
+    {
+        return $this->hasMany(UserProfile::class);
     }
 }

--- a/tests/Models/UserProfile.php
+++ b/tests/Models/UserProfile.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Awobaz\Compoships\Tests\Models;
+
+use Awobaz\Compoships\Compoships;
+use Awobaz\Compoships\Tests\Enums\UserProfileType;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int             $user_id
+ * @property UserProfileType $user_profile_type
+ * @property Carbon          $created_at
+ * @property Carbon          $updated_at
+ * @property-read Collection<UserProfileText> $userProfileTexts
+ *
+ * @mixin \Illuminate\Database\Eloquent\Builder
+ */
+class UserProfile extends Model
+{
+    use Compoships;
+
+    // NOTE: we need this because Laravel 7 uses Carbon's method toJSON() instead of toDateTimeString()
+    protected $casts = [
+        'created_at'        => 'datetime:Y-m-d H:i:s',
+        'updated_at'        => 'datetime:Y-m-d H:i:s',
+        'user_profile_type' => UserProfileType::class,
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function userProfileTexts()
+    {
+        return $this->hasMany(UserProfileText::class, ['user_id', 'user_profile_type'], ['user_id', 'user_profile_type']);
+    }
+}

--- a/tests/Models/UserProfileText.php
+++ b/tests/Models/UserProfileText.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Awobaz\Compoships\Tests\Models;
+
+use Awobaz\Compoships\Compoships;
+use Awobaz\Compoships\Tests\Enums\UserProfileType;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int             $user_id
+ * @property UserProfileType $user_profile_type
+ * @property string          $user_profile_text
+ * @property Carbon          $created_at
+ * @property Carbon          $updated_at
+ *
+ * @mixin \Illuminate\Database\Eloquent\Builder
+ */
+class UserProfileText extends Model
+{
+    use Compoships;
+
+    // NOTE: we need this because Laravel 7 uses Carbon's method toJSON() instead of toDateTimeString()
+    protected $casts = [
+        'created_at'        => 'datetime:Y-m-d H:i:s',
+        'updated_at'        => 'datetime:Y-m-d H:i:s',
+        'user_profile_type' => UserProfileType::class,
+    ];
+
+    public function userProfile()
+    {
+        return $this->belongsTo(UserProfile::class, ['user_id', 'user_profile_type'], ['user_id', 'user_profile_type']);
+    }
+}

--- a/tests/Unit/RelationWithEnumTest.php
+++ b/tests/Unit/RelationWithEnumTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Awobaz\Compoships\Tests\Unit;
+
+use Awobaz\Compoships\Tests\Enums\UserProfileType;
+use Awobaz\Compoships\Tests\Models\User;
+use Awobaz\Compoships\Tests\Models\UserProfile;
+use Awobaz\Compoships\Tests\Models\UserProfileText;
+use Awobaz\Compoships\Tests\TestCase\TestCase;
+use Illuminate\Database\Eloquent\Model;
+
+class RelationWithEnumTest extends TestCase
+{
+    /**
+     * @var User
+     */
+    private $user;
+
+    public function setUp(): void
+    {
+        if (getPHPVersion() < 8.1) {
+            $this->markTestSkipped('This test requires PHP 8.1 or higher');
+        }
+
+        Model::unguard();
+
+        $user = new User();
+        $user->save();
+
+        $user->userProfiles()->createMany([
+            ['user_profile_type' => UserProfileType::Email],
+            ['user_profile_type' => UserProfileType::Url],
+        ]);
+
+        $user->userProfiles->each(function ($userProfile) {
+            $userProfile->userProfileTexts()->createMany([
+                ['user_profile_text' => 'text_1'],
+                ['user_profile_text' => 'text_2'],
+            ]);
+        });
+
+        $this->user = User::first();
+    }
+
+    /**
+     * @covers \Awobaz\Compoships\Database\Eloquent\Relations\HasOneOrMany
+     */
+    public function test_lazy_load_has_many_relation_with_enum()
+    {
+        $this->assertNotEmpty($this->user->userProfiles);
+
+        $this->user->userProfiles->each(function (UserProfile $userProfile) {
+            $this->assertInstanceOf(UserProfileType::class, $userProfile->user_profile_type);
+        });
+    }
+
+    /**
+     * @covers \Awobaz\Compoships\Database\Eloquent\Relations\HasOneOrMany
+     */
+    public function test_eager_load_has_many_relation_with_enum()
+    {
+        $this->user->load('userProfiles');
+
+        $this->assertNotEmpty($this->user->userProfiles);
+
+        $this->user->userProfiles->each(function (UserProfile $userProfile) {
+            $this->assertInstanceOf(UserProfileType::class, $userProfile->user_profile_type);
+        });
+    }
+
+    /**
+     * @covers \Awobaz\Compoships\Database\Eloquent\Relations\BelongsTo
+     */
+    public function test_lazy_load_belongs_to_relation_with_enum()
+    {
+        $userProfiles = UserProfile::all();
+
+        $this->assertNotEmpty($userProfiles);
+
+        $userProfiles->each(function (UserProfile $userProfile) {
+            $this->assertInstanceOf(User::class, $userProfile->user);
+        });
+    }
+
+    /**
+     * @covers \Awobaz\Compoships\Database\Eloquent\Relations\BelongsTo
+     */
+    public function test_eager_load_belongs_to_relation_with_enum()
+    {
+        $userProfiles = UserProfile::with('user')->get();
+
+        $this->assertNotEmpty($userProfiles);
+
+        $userProfiles->each(function (UserProfile $userProfile) {
+            $this->assertInstanceOf(User::class, $userProfile->user);
+        });
+    }
+
+    /**
+     * @covers \Awobaz\Compoships\Database\Eloquent\Relations\HasOneOrMany
+     */
+    public function test_lazy_load_has_many_relation_with_enum_and_composite_key()
+    {
+        $this->assertNotEmpty($this->user->userProfiles);
+
+        $this->user->userProfiles->each(function (UserProfile $userProfile) {
+            $this->assertNotEmpty($userProfile->userProfileTexts);
+
+            $userProfile->userProfileTexts->each(function (UserProfileText $userProfileText) {
+                $this->assertInstanceOf(UserProfileType::class, $userProfileText->user_profile_type);
+            });
+        });
+    }
+
+    /**
+     * @covers \Awobaz\Compoships\Database\Eloquent\Relations\HasOneOrMany
+     */
+    public function test_eager_load_has_many_relation_with_enum_and_composite_key()
+    {
+        $this->user->load('userProfiles.userProfileTexts');
+
+        $this->assertNotEmpty($this->user->userProfiles);
+
+        $this->user->userProfiles->each(function (UserProfile $userProfile) {
+            $this->assertNotEmpty($userProfile->userProfileTexts);
+
+            $userProfile->userProfileTexts->each(function (UserProfileText $userProfileText) {
+                $this->assertInstanceOf(UserProfileType::class, $userProfileText->user_profile_type);
+            });
+        });
+    }
+
+    /**
+     * @covers \Awobaz\Compoships\Database\Eloquent\Relations\BelongsTo
+     */
+    public function test_lazy_load_belongs_to_relation_with_enum_and_composite_key()
+    {
+        $userProfileTexts = UserProfileText::all();
+
+        $this->assertNotEmpty($userProfileTexts);
+
+        $userProfileTexts->each(function (UserProfileText $userProfileText) {
+            $this->assertInstanceOf(UserProfile::class, $userProfileText->userProfile);
+        });
+    }
+
+    /**
+     * @covers \Awobaz\Compoships\Database\Eloquent\Relations\BelongsTo
+     */
+    public function test_eager_load_belongs_to_relation_with_enum_and_composite_key()
+    {
+        $userProfileTexts = UserProfileText::with('userProfile')->get();
+
+        $this->assertNotEmpty($userProfileTexts);
+
+        $userProfileTexts->each(function (UserProfileText $userProfileText) {
+            $this->assertInstanceOf(UserProfile::class, $userProfileText->userProfile);
+        });
+    }
+}


### PR DESCRIPTION
resolves #168, resolves: #176

Fixed an issue where relationships could not be retrieved if a composite key contained a value casted to an enum.

PHP 8.1, Laravel 8, supports the ability to cast specific column values ​​to `BackedEnum` and reference them from an Eloquent model.

Reference:
https://laravel.com/docs/8.x/eloquent-mutators#enum-casting

However, our library did not support this feature. If a BackedEnum value is included as part of a composite key, retrieving a relationship would crash.

* Lazy loading of `HasMany` relationships
* Eager loading of `HasMany` relationships
* Eager loading of `BenlongTo` relationships

All of these issues are caused by our library assuming that the key value can be interpreted as a `string`. In `addConstraints` before query execution and `match` after execution, the key is evaluated as a string using `implode` or `array_unique`.

An attribute cast to a BackEnum has its *backed value* before the cast, so evaluating `$backedEum->value` instead of `$backedEnum` in the offending operation will solve this issue.
