### PR TITLE
fix: wrap column names in whereIn for composite keys

### DIFF
--- a/src/Database/Query/Builder.php
+++ b/src/Database/Query/Builder.php
@@ -22,13 +22,14 @@ class Builder extends BaseQueryBuilder
         // Here we implement custom support for multi-column 'IN'
         if (is_array($column)) {
             $inOperator = $not ? 'NOT IN' : 'IN';
-            $prefix = $this->getConnection()->getTablePrefix();
-
-            foreach ($column as &$value) {
-                $value = $prefix.$value;
-            }
 
             if ($this->getConnection()->getDriverName() === 'sqlsrv') {
+                $prefix = $this->getConnection()->getTablePrefix();
+
+                foreach ($column as &$value) {
+                    $value = $prefix.$value;
+                }
+
                 foreach ($column as $column_number => $column_name) {
                     $column_values = array_unique(Arr::pluck($values, $column_number));
                     $values_placeholders = implode(', ', array_fill(0, count($column_values), '?'));
@@ -39,7 +40,7 @@ class Builder extends BaseQueryBuilder
                 return $this;
             }
 
-            $columns = implode(',', $column);
+            $columns = implode(',', array_map(fn ($c) => $this->grammar->wrap($c), $column));
             $tuplePlaceholders = '('.implode(', ', array_fill(0, count($column), '?')).')';
             $placeholderList = implode(',', array_fill(0, count($values), $tuplePlaceholders));
 

--- a/tests/Unit/BuilderTest.php
+++ b/tests/Unit/BuilderTest.php
@@ -3,6 +3,7 @@
 namespace Awobaz\Compoships\Tests\Unit;
 
 use Awobaz\Compoships\Tests\Models\Allocation;
+use Awobaz\Compoships\Tests\Models\TrackingTask;
 use Awobaz\Compoships\Tests\TestCase\TestCase;
 use Illuminate\Database\Capsule\Manager as Capsule;
 
@@ -57,5 +58,19 @@ class BuilderTest extends TestCase
         })->get();
         $this->assertCount(1, $allocations);
         $this->assertCount(2, $allocations[0]->originalPackages);
+    }
+
+    /** @covers \Awobaz\Compoships\Database\Query\Builder::whereIn */
+    public function testWhereInWrapsColumnNamesForCompositeKeys(): void
+    {
+        $query = TrackingTask::query()->whereIn(
+            ['tracking_tasks.booking_id', 'tracking_tasks.vehicle_id'],
+            [[1, 2], [3, 4]],
+        );
+
+        $this->assertSame(
+            'select * from "tracking_tasks" where ("tracking_tasks"."booking_id","tracking_tasks"."vehicle_id") IN ((?, ?),(?, ?)) and "tracking_tasks"."deleted_at" is null',
+            $query->toSql(),
+        );
     }
 }


### PR DESCRIPTION
Hello!

This commit fixes a bug where column names in whereIn clauses for composite keys were not wrapped in the table prefix.

Closes #201