### PR TITLE
Laravel 13 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                laravel: [12.*, 11.*, 10.*, 9.*]
+                laravel: [13.*, 12.*, 11.*, 10.*, 9.*]
                 php: ['8.5', '8.4', '8.3', '8.2', '8.1', '8.0']
                 include:
                     - laravel: 8.*
@@ -48,6 +48,12 @@ jobs:
                     - laravel: 5.6
                       php: '7.1'
                 exclude:
+                    - laravel: 13.*
+                      php: '8.2'
+                    - laravel: 13.*
+                      php: '8.1'
+                    - laravel: 13.*
+                      php: '8.0'
                     - laravel: 12.*
                       php: '8.1'
                     - laravel: 12.*
@@ -83,7 +89,7 @@ jobs:
                     coverage: none
 
             -   name: Fix dependencies
-                if: ${{ startsWith(matrix.laravel, '11') || startsWith(matrix.laravel, '12') }}
+                if: ${{ startsWith(matrix.laravel, '11') || startsWith(matrix.laravel, '12') || startsWith(matrix.laravel, '13') }}
                 run: |
                     composer require "laravel/serializable-closure:>=1.3" --no-interaction --no-update
             -   name: Install dependencies

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "illuminate/database": ">=5.6 <13.0"
+    "illuminate/database": ">=5.6 <14.0"
   },
   "require-dev": {
     "ext-sqlite3": "*",


### PR DESCRIPTION
 Add support for Laravel 13 (illuminate/database 13.x).

- Update `composer.json` version constraint to `>=5.6 <14.0`
- Add Laravel 13 to GitHub Actions test matrix (PHP 8.3, 8.4, 8.5)
- No source code changes required — existing compatibility layers already handle Laravel 13