### PR TITLE
fix: handle Expression::getValue($grammar) for Laravel 10+

### DIFF
--- a/src/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Database/Eloquent/Concerns/HasRelationships.php
@@ -318,7 +318,7 @@ trait HasRelationships
         $grammar = $this->getConnection()
             ->getQueryGrammar();
 
-        return $grammar->isExpression($foreignKey)
+        return $grammar->isExpression($foreignKey) || Str::contains($foreignKey, '.')
             ? $foreignKey
             : $instance->getTable().'.'.$foreignKey;
     }

--- a/src/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Database/Eloquent/Relations/HasOneOrMany.php
@@ -120,6 +120,7 @@ trait HasOneOrMany
 
         if (is_array($key)) { //Check for multi-columns relationship
             $grammar = $this->getConnection()->getQueryGrammar();
+
             return array_map(fn ($k) => last(explode('.', $grammar->isExpression($k) ? $k->getValue($grammar) : $k)), $key);
         } else {
             return last(explode('.', $key));

--- a/src/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Database/Eloquent/Relations/HasOneOrMany.php
@@ -32,10 +32,14 @@ trait HasOneOrMany
                 $allParentKeyValuesAreNull = array_unique($parentKeyValue) === [null];
 
                 foreach ($this->foreignKey as $index => $key) {
-                    $tmp = explode('.', $key);
-                    $key = end($tmp);
-                    $fullKey = $this->getRelated()
-                            ->getTable().'.'.$key;
+                    if (is_string($key)) {
+                        $tmp = explode('.', $key);
+                        $key = end($tmp);
+                        $fullKey = $this->getRelated()
+                                ->getTable().'.'.$key;
+                    } else {
+                        $fullKey = $key;
+                    }
                     $this->query->where($fullKey, '=', $parentKeyValue[$index]);
 
                     if ($allParentKeyValuesAreNull) {
@@ -115,7 +119,8 @@ trait HasOneOrMany
         $key = $this->getQualifiedForeignKeyName();
 
         if (is_array($key)) { //Check for multi-columns relationship
-            return array_map(fn ($k) => last(explode('.', $k)), $key);
+            $grammar = $this->getConnection()->getQueryGrammar();
+            return array_map(fn ($k) => last(explode('.', $grammar->isExpression($k) ? $k->getValue($grammar) : $k)), $key);
         } else {
             return last(explode('.', $key));
         }

--- a/src/Database/Query/Builder.php
+++ b/src/Database/Query/Builder.php
@@ -23,9 +23,12 @@ class Builder extends BaseQueryBuilder
         if (is_array($column)) {
             $inOperator = $not ? 'NOT IN' : 'IN';
             $prefix = $this->getConnection()->getTablePrefix();
+            $grammar = $this->getConnection()->getQueryGrammar();
 
             foreach ($column as &$value) {
-                $value = $prefix.$value;
+                if (!$grammar->isExpression($value)) {
+                    $value = $prefix.$value;
+                }
             }
 
             if ($this->getConnection()->getDriverName() === 'sqlsrv') {
@@ -38,8 +41,11 @@ class Builder extends BaseQueryBuilder
 
                 return $this;
             }
-
-            $columns = implode(',', $column);
+            
+            $columns = implode(',', array_map(
+                fn ($v) => $grammar->isExpression($v) ? $v->getValue($grammar) : $v,
+                $column
+            ));
             $tuplePlaceholders = '('.implode(', ', array_fill(0, count($column), '?')).')';
             $placeholderList = implode(',', array_fill(0, count($values), $tuplePlaceholders));
 

--- a/src/Database/Query/Builder.php
+++ b/src/Database/Query/Builder.php
@@ -42,7 +42,7 @@ class Builder extends BaseQueryBuilder
 
                 return $this;
             }
-            
+
             $columns = implode(', ', array_map(
                 fn ($v) => $grammar->isExpression($v) ? $v->getValue($grammar) : $grammar->wrap($v),
                 $column

--- a/src/Database/Query/Builder.php
+++ b/src/Database/Query/Builder.php
@@ -4,6 +4,7 @@ namespace Awobaz\Compoships\Database\Query;
 
 use Illuminate\Database\Query\Builder as BaseQueryBuilder;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 class Builder extends BaseQueryBuilder
 {
@@ -26,7 +27,7 @@ class Builder extends BaseQueryBuilder
             $grammar = $this->getConnection()->getQueryGrammar();
 
             foreach ($column as &$value) {
-                if (!$grammar->isExpression($value)) {
+                if (!$grammar->isExpression($value) && !Str::contains($value, '.')) {
                     $value = $prefix.$value;
                 }
             }
@@ -42,12 +43,12 @@ class Builder extends BaseQueryBuilder
                 return $this;
             }
             
-            $columns = implode(',', array_map(
-                fn ($v) => $grammar->isExpression($v) ? $v->getValue($grammar) : $v,
+            $columns = implode(', ', array_map(
+                fn ($v) => $grammar->isExpression($v) ? $v->getValue($grammar) : $grammar->wrap($v),
                 $column
             ));
             $tuplePlaceholders = '('.implode(', ', array_fill(0, count($column), '?')).')';
-            $placeholderList = implode(',', array_fill(0, count($values), $tuplePlaceholders));
+            $placeholderList = implode(', ', array_fill(0, count($values), $tuplePlaceholders));
 
             $this->whereRaw("({$columns}) {$inOperator} ({$placeholderList})", Arr::flatten($values), $boolean);
 

--- a/tests/Models/Allocation.php
+++ b/tests/Models/Allocation.php
@@ -54,6 +54,14 @@ class Allocation extends Model
     /**
      * @return \Awobaz\Compoships\Database\Eloquent\Relations\HasMany
      */
+    public function trackingTasksWithPrefixedField()
+    {
+        return $this->hasMany(TrackingTask::class, ['booking_id', 'tracking_tasks.vehicle_id'], ['booking_id', 'vehicle_id']);
+    }
+
+    /**
+     * @return \Awobaz\Compoships\Database\Eloquent\Relations\HasMany
+     */
     public function originalPackages()
     {
         $hasMany = $this->hasMany(OriginalPackage::class);

--- a/tests/Models/Allocation.php
+++ b/tests/Models/Allocation.php
@@ -6,6 +6,7 @@ use Awobaz\Compoships\Compoships;
 use Awobaz\Compoships\Tests\Factories\AllocationFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
@@ -40,6 +41,14 @@ class Allocation extends Model
     public function trackingTasks()
     {
         return $this->hasMany(TrackingTask::class, ['booking_id', 'vehicle_id'], ['booking_id', 'vehicle_id']);
+    }
+
+    /**
+     * @return \Awobaz\Compoships\Database\Eloquent\Relations\HasMany
+     */
+    public function trackingTasksWithRaw()
+    {
+        return $this->hasMany(TrackingTask::class, ['booking_id', new Expression('("tracking_tasks" . "vehicle_id" /*test*/)')], ['booking_id', 'vehicle_id']);
     }
 
     /**

--- a/tests/Unit/HasManyTest.php
+++ b/tests/Unit/HasManyTest.php
@@ -256,6 +256,52 @@ class HasManyTest extends TestCase
     /**
      * @covers \Awobaz\Compoships\Database\Query\Builder::whereIn
      */
+    public function test_Compoships_eagerLoading_using_expression()
+    {
+        $allocationId1 = Capsule::table('allocations')->insertGetId([
+            'booking_id' => 2,
+            'vehicle_id' => 2,
+        ]);
+        $allocationId2 = Capsule::table('allocations')->insertGetId([
+            'booking_id' => 1,
+            'vehicle_id' => 1,
+        ]);
+        Capsule::table('tracking_tasks')->insertGetId([
+            'booking_id' => 1,
+            'vehicle_id' => 1,
+            'created_at' => Carbon::now()
+                ->toDateTimeString(),
+            'updated_at' => Carbon::now()
+                ->toDateTimeString(),
+            'deleted_at' => null,
+        ]);
+
+        Capsule::connection()->enableQueryLog();
+        $allocations1 = Allocation::where('id', $allocationId1)->with('trackingTasksWithRaw')->get()->all();
+        $allocations2 = Allocation::where('id', $allocationId2)->with('trackingTasksWithRaw')->get()->all();
+        $queries = Capsule::connection()->getQueryLog();
+        Capsule::connection()->disableQueryLog();
+
+        $this->assertSame(
+            'select * from "tracking_tasks" where (tracking_tasks.booking_id,("tracking_tasks" . "vehicle_id" /*test*/)) IN ((?, ?)) and "tracking_tasks"."deleted_at" is null',
+            last($queries)['query'],
+        );
+        $this->assertSame(
+            'select * from "tracking_tasks" where "tracking_tasks"."booking_id" = ? and ("tracking_tasks" . "vehicle_id" /*test*/) = ? and "tracking_tasks"."deleted_at" is null',
+            $allocations2[0]->trackingTasksWithRaw()->toSql(),
+        );
+
+        $this->assertCount(1, $allocations2);
+        $this->assertCount(1, $allocations2[0]->trackingTasks);
+        $this->assertEquals(1, $allocations2[0]->trackingTasks[0]->id);
+
+        $this->assertCount(1, $allocations1);
+        $this->assertCount(0, $allocations1[0]->trackingTasks);
+    }
+
+    /**
+     * @covers \Awobaz\Compoships\Database\Query\Builder::whereIn
+     */
     public function test_Illuminate_eagerLoading()
     {
         $allocationId1 = Capsule::table('allocations')->insertGetId([

--- a/tests/Unit/HasManyTest.php
+++ b/tests/Unit/HasManyTest.php
@@ -387,7 +387,6 @@ class HasManyTest extends TestCase
 
     public function test_Illuminate_chaperone()
     {
-
         $allocationId1 = Capsule::table('allocations')->insertGetId([
             'booking_id' => 1,
             'vehicle_id' => 1,

--- a/tests/Unit/HasManyTest.php
+++ b/tests/Unit/HasManyTest.php
@@ -283,12 +283,58 @@ class HasManyTest extends TestCase
         Capsule::connection()->disableQueryLog();
 
         $this->assertSame(
-            'select * from "tracking_tasks" where (tracking_tasks.booking_id,("tracking_tasks" . "vehicle_id" /*test*/)) IN ((?, ?)) and "tracking_tasks"."deleted_at" is null',
+            'select * from "tracking_tasks" where ("tracking_tasks"."booking_id", ("tracking_tasks" . "vehicle_id" /*test*/)) IN ((?, ?)) and "tracking_tasks"."deleted_at" is null',
             last($queries)['query'],
         );
         $this->assertSame(
             'select * from "tracking_tasks" where "tracking_tasks"."booking_id" = ? and ("tracking_tasks" . "vehicle_id" /*test*/) = ? and "tracking_tasks"."deleted_at" is null',
             $allocations2[0]->trackingTasksWithRaw()->toSql(),
+        );
+
+        $this->assertCount(1, $allocations2);
+        $this->assertCount(1, $allocations2[0]->trackingTasks);
+        $this->assertEquals(1, $allocations2[0]->trackingTasks[0]->id);
+
+        $this->assertCount(1, $allocations1);
+        $this->assertCount(0, $allocations1[0]->trackingTasks);
+    }
+
+    /**
+     * @covers \Awobaz\Compoships\Database\Query\Builder::whereIn
+     */
+    public function test_Compoships_eagerLoading_using_prefixed_field()
+    {
+        $allocationId1 = Capsule::table('allocations')->insertGetId([
+            'booking_id' => 2,
+            'vehicle_id' => 2,
+        ]);
+        $allocationId2 = Capsule::table('allocations')->insertGetId([
+            'booking_id' => 1,
+            'vehicle_id' => 1,
+        ]);
+        Capsule::table('tracking_tasks')->insertGetId([
+            'booking_id' => 1,
+            'vehicle_id' => 1,
+            'created_at' => Carbon::now()
+                ->toDateTimeString(),
+            'updated_at' => Carbon::now()
+                ->toDateTimeString(),
+            'deleted_at' => null,
+        ]);
+
+        Capsule::connection()->enableQueryLog();
+        $allocations1 = Allocation::where('id', $allocationId1)->with('trackingTasksWithPrefixedField')->get()->all();
+        $allocations2 = Allocation::where('id', $allocationId2)->with('trackingTasksWithPrefixedField')->get()->all();
+        $queries = Capsule::connection()->getQueryLog();
+        Capsule::connection()->disableQueryLog();
+
+        $this->assertSame(
+            'select * from "tracking_tasks" where ("tracking_tasks"."booking_id", "tracking_tasks"."vehicle_id") IN ((?, ?)) and "tracking_tasks"."deleted_at" is null',
+            last($queries)['query'],
+        );
+        $this->assertSame(
+            'select * from "tracking_tasks" where "tracking_tasks"."booking_id" = ? and "tracking_tasks"."vehicle_id" = ? and "tracking_tasks"."deleted_at" is null',
+            $allocations2[0]->trackingTasksWithPrefixedField()->toSql(),
         );
 
         $this->assertCount(1, $allocations2);


### PR DESCRIPTION
Prior to Laravel 10, `Expression` objects implemented `__toString()`, so casting them to string directly (e.g. `(string) $expression` or `"" . $expression`) worked out of the box.

Starting in Laravel 10, `__toString()` was removed from `Expression` and `getValue()` now requires a `Grammar` instance as an argument. This means direct string casting silently breaks or throws an error depending on the context.

This PR updates `Expression`-to-string conversions to use `$expression->getValue($grammar)`, fetching the grammar via `$connection->getQueryGrammar()` when needed

It can also be added to v2, but there is no branch available.

---- 

**UPDATE:**

This commit fixes a bug where column names in whereIn clauses for composite keys were not wrapped in the table prefix.

Closes #201
>`$columns` are concatenated without using the grammar’s `wrap()` method.
This results in unquoted identifiers, which break in databases like **PostgreSQL**,
where unquoted names are automatically lowercased — causing table/column name mismatches.

Alternative to #209
