### PR TITLE
Handle potential null values in dictionary keys(php8.5 deprecation)

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd" executionOrder="depends,defects" beStrictAboutOutputDuringTests="true" backupGlobals="false" bootstrap="tests/bootstrap.php" colors="true" processIsolation="false" stopOnFailure="false" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
+  executionOrder="depends,defects"
+  beStrictAboutOutputDuringTests="true"
+  backupGlobals="false"
+  bootstrap="tests/bootstrap.php"
+  colors="true"
+  processIsolation="false"
+  stopOnFailure="false"
+  cacheDirectory=".phpunit.cache"
+  backupStaticProperties="false"
+  failOnDeprecation="false"
+  displayDetailsOnTestsThatTriggerDeprecations="true"
+  displayDetailsOnTestsThatTriggerErrors="true"
+  displayDetailsOnTestsThatTriggerNotices="true"
+  displayDetailsOnTestsThatTriggerWarnings="true"
+  displayDetailsOnPhpunitDeprecations="true"
+>
   <testsuites>
     <testsuite name="Package Test Suite">
       <directory suffix="Test.php">./tests</directory>

--- a/src/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Database/Eloquent/Relations/BelongsTo.php
@@ -231,7 +231,7 @@ class BelongsTo extends BaseBelongsTo
 
                 $dictionary[implode('-', $dictKeyValues)] = $result;
             } else {
-                $dictionary[$result->getAttribute($owner)] = $result;
+                $dictionary[$result->getAttribute($owner) ?? ''] = $result;
             }
         }
 
@@ -244,7 +244,7 @@ class BelongsTo extends BaseBelongsTo
 
                 $key = implode('-', $dictKeyValues);
             } else {
-                $key = $model->{$foreign};
+                $key = $model->{$foreign} ?? '';
             }
 
             if (isset($dictionary[$key])) {

--- a/src/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Database/Eloquent/Relations/BelongsToMany.php
@@ -175,7 +175,7 @@ class BelongsToMany extends BaseBelongsToMany
         $dictionary = $this->buildDictionary($results);
 
         foreach ($models as $model) {
-            $key = $this->buildDictionaryKey($model, $this->parentKey);
+            $key = $this->buildDictionaryKey($model, $this->parentKey) ?? '';
 
             if (isset($dictionary[$key])) {
                 $model->setRelation(
@@ -204,7 +204,7 @@ class BelongsToMany extends BaseBelongsToMany
         $dictionary = [];
 
         foreach ($results as $result) {
-            $key = $this->buildDictionaryKey($result->{$this->accessor}, $this->foreignPivotKey);
+            $key = $this->buildDictionaryKey($result->{$this->accessor}, $this->foreignPivotKey) ?? '';
             $dictionary[$key][] = $result;
         }
 

--- a/src/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Database/Eloquent/Relations/HasOneOrMany.php
@@ -219,7 +219,7 @@ trait HasOneOrMany
             //And we join the values to construct the dictionary key
             $dictKey = is_array($key)
                 ? implode('-', array_map(fn ($v) => $this->resolveBackedEnumValue($v), $key))
-                : $key;
+                : ($key ?? '');
 
             if (isset($dictionary[$dictKey])) {
                 $related = $this->getRelationValue($dictionary, $dictKey, $type);
@@ -262,7 +262,7 @@ trait HasOneOrMany
                 //... so we join the values to construct the dictionary key
                 $dictionary[implode('-', $dictKeyValues)][] = $result;
             } else {
-                $dictionary[$result->{$foreign}][] = $result;
+                $dictionary[$result->{$foreign} ?? ''][] = $result;
             }
         }
 


### PR DESCRIPTION
Closes #208
>https://www.php.net/manual/en/migration85.deprecated.php
"Using null as an array offset or when calling array_key_exists() is now deprecated. Instead an empty string should be used."
> ...
>The deprecation happens in Database/Eloquent/Relations/HasOneOrMany.php where dictKey will be null, which causes array null offset ...