### PR TITLE
Fix type-sensitive composite sync/toggle and malformed tuple whereIn

### DIFF
--- a/src/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Database/Eloquent/Relations/BelongsToMany.php
@@ -550,23 +550,29 @@ class BelongsToMany extends BaseBelongsToMany
     }
 
     /**
-     * Normalize a sync/toggle records map so all entries are keyed by the
-     * canonical JSON-encoded composite tuple matching `relatedPivotKey`.
+     * Normalize a sync/toggle records map into canonical composite entries:
+     *
+     *   [canonicalKey => ['tuple' => array, 'attributes' => array]]
      *
      * Accepts entries whose key is either:
-     *   - already a JSON-encoded tuple of matching arity (passed through), or
+     *   - a JSON-encoded tuple of matching arity (decoded and re-serialized
+     *     canonically, so key formatting and scalar types cannot affect
+     *     matching), or
      *   - a scalar id (UUID, string, int) that fills `relatedPivotKey[0]`. The
      *     remaining composite columns are looked up first in the per-row attrs,
      *     then in the parent's matching `parentKey` column (for shared columns
      *     like `sem_id` that span both pivot sides).
      *
-     * Without this normalization, `array_diff` against the JSON-encoded result
-     * of `getCurrentPivotKeys()` would never match scalar-keyed entries, so
-     * sync would mistakenly detach every existing pivot row.
+     * The canonical key (see `serializeCompositeKey`) makes the set operations
+     * against `getCurrentPivotKeys()` type-agnostic, while the stored tuple
+     * preserves the caller's values for attach payloads and the returned
+     * change sets. Without both, a driver returning key columns with a
+     * different scalar type than the caller supplied (e.g. int read back as
+     * string) would classify already-attached rows as "to detach".
      *
      * @param array $records
      *
-     * @return array
+     * @return array<string, array{tuple: array, attributes: array}>
      */
     protected function normalizeRecordKeys(array $records): array
     {
@@ -579,17 +585,43 @@ class BelongsToMany extends BaseBelongsToMany
         foreach ($records as $key => $attrs) {
             $attributes = is_array($attrs) ? $attrs : [];
 
-            if (is_string($key) && $this->decodeCompositeKey($key) !== null) {
-                $normalized[$key] = $attributes;
-                continue;
+            $tuple = $this->decodeCompositeKey($key);
+
+            if ($tuple === null) {
+                $tuple = $this->buildCompositeTupleFromScalar($key, $attributes);
             }
 
-            $tuple = $this->buildCompositeTupleFromScalar($key, $attributes);
+            $tuple = array_map(fn ($value) => $this->resolveBackedEnumValue($value), array_values($tuple));
 
-            $normalized[json_encode($tuple)] = $attributes;
+            $normalized[$this->serializeCompositeKey($tuple)] = [
+                'tuple'      => $tuple,
+                'attributes' => $attributes,
+            ];
         }
 
         return $normalized;
+    }
+
+    /**
+     * Serialize a composite tuple to its canonical comparison key.
+     *
+     * Backed enums are resolved to their backing scalar and every non-null
+     * component is cast to string before encoding, so a key built from caller
+     * input compares equal to a key built from driver results whenever the
+     * components are equal by value (int 1 matches string '1'). Null is kept
+     * as JSON null so it can never collide with an empty-string component.
+     *
+     * @param array $tuple
+     *
+     * @return string
+     */
+    protected function serializeCompositeKey(array $tuple): string
+    {
+        return json_encode(array_map(function ($value) {
+            $value = $this->resolveBackedEnumValue($value);
+
+            return $value === null ? null : (string) $value;
+        }, array_values($tuple)));
     }
 
     /**
@@ -769,7 +801,7 @@ class BelongsToMany extends BaseBelongsToMany
 
         return $this->newPivotQuery()->whereIn(
             $this->qualifyPivotColumn($this->relatedPivotKey),
-            $this->wrapAsTupleList($id)
+            $this->normalizeTupleList($id)
         );
     }
 
@@ -806,6 +838,43 @@ class BelongsToMany extends BaseBelongsToMany
     }
 
     /**
+     * Normalize a detach/update `$ids` argument into an arity-validated list
+     * of composite tuples for a `whereIn(<column tuple>, ...)` clause.
+     *
+     * Runs `parseIds` (Model/Collection extraction) and `wrapAsTupleList`
+     * (shape normalization), then rejects any tuple whose arity does not
+     * match `relatedPivotKey`. Without this guard a malformed tuple expands
+     * into a placeholder/binding count mismatch: silently wrong on SQLite
+     * (unbound placeholders become NULL) and a hard protocol error on
+     * PostgreSQL (SQLSTATE 08P01).
+     *
+     * @param mixed $ids
+     *
+     * @throws \Awobaz\Compoships\Exceptions\InvalidUsageException
+     *
+     * @return array<int, array>
+     */
+    protected function normalizeTupleList($ids): array
+    {
+        $tuples = $this->wrapAsTupleList($this->parseIds($ids));
+
+        $arity = count($this->relatedPivotKey);
+
+        foreach ($tuples as $tuple) {
+            if (!is_array($tuple) || count($tuple) !== $arity) {
+                throw new InvalidUsageException(sprintf(
+                    'Composite-key tuple %s does not match the relation arity %d (relatedPivotKey columns: %s).',
+                    var_export($tuple, true),
+                    $arity,
+                    implode(', ', $this->relatedPivotKey)
+                ));
+            }
+        }
+
+        return $tuples;
+    }
+
+    /**
      * Detach models from the relationship.
      *
      * @param mixed $ids
@@ -830,10 +899,7 @@ class BelongsToMany extends BaseBelongsToMany
             $query = $this->newPivotQuery();
 
             if (!is_null($ids)) {
-                // parseIds first to extract composite tuples from Model/Collection
-                // inputs, then wrapAsTupleList to ensure the result is a list of
-                // tuples for the `whereIn(<column tuple>, [[...], ...])` clause.
-                $ids = $this->wrapAsTupleList($this->parseIds($ids));
+                $ids = $this->normalizeTupleList($ids);
 
                 if (empty($ids)) {
                     return 0;
@@ -893,11 +959,17 @@ class BelongsToMany extends BaseBelongsToMany
             return parent::getCurrentlyAttachedPivotsForIds($ids);
         }
 
+        $tuples = is_null($ids) ? null : $this->normalizeTupleList($ids);
+
+        if ($tuples === []) {
+            return new SupportCollection();
+        }
+
         return $this->newPivotQuery()
-            ->when(!is_null($ids), function ($query) use ($ids) {
+            ->when(!is_null($tuples), function ($query) use ($tuples) {
                 return $query->whereIn(
                     $this->qualifyPivotColumn($this->relatedPivotKey),
-                    $this->parseIds($ids)
+                    $tuples
                 );
             })
             ->get()
@@ -969,14 +1041,12 @@ class BelongsToMany extends BaseBelongsToMany
         $current = $this->getCurrentPivotKeys();
 
         if ($detaching) {
-            $detach = array_diff($current, array_keys($records));
+            $detach = array_values(array_diff_key($current, $records));
 
             if (count($detach) > 0) {
-                $detachValues = array_values($detach);
+                $this->detach($detach, false);
 
-                $this->detach($this->decodeJsonKeys($detachValues), false);
-
-                $changes['detached'] = $this->decodeJsonKeys($detachValues);
+                $changes['detached'] = $detach;
             }
         }
 
@@ -1017,22 +1087,22 @@ class BelongsToMany extends BaseBelongsToMany
         );
         $current = $this->getCurrentPivotKeys();
 
-        $detach = array_values(array_intersect($current, array_keys($records)));
+        $detach = array_values(array_intersect_key($current, $records));
 
         if (count($detach) > 0) {
-            $this->detach($this->decodeJsonKeys($detach), false);
+            $this->detach($detach, false);
 
-            $changes['detached'] = $this->decodeJsonKeys($detach);
+            $changes['detached'] = $detach;
         }
 
-        $attach = array_diff_key($records, array_flip($detach));
+        $attach = array_diff_key($records, $current);
 
         if (count($attach) > 0) {
-            foreach ($attach as $serializedId => $attributes) {
-                $this->attach([json_decode($serializedId, true)], $attributes, false);
+            foreach ($attach as $record) {
+                $this->attach([$record['tuple']], $record['attributes'], false);
             }
 
-            $changes['attached'] = $this->decodeJsonKeys(array_keys($attach));
+            $changes['attached'] = array_column($attach, 'tuple');
         }
 
         if ($touch && (count($changes['attached']) || count($changes['detached']))) {
@@ -1059,16 +1129,14 @@ class BelongsToMany extends BaseBelongsToMany
 
         $changes = ['attached' => [], 'updated' => []];
 
-        foreach ($records as $id => $attributes) {
-            $tuple = json_decode($id, true);
+        foreach ($records as $key => $record) {
+            if (!array_key_exists($key, $current)) {
+                $this->attach([$record['tuple']], $record['attributes'], $touch);
 
-            if (!in_array($id, $current)) {
-                $this->attach([$tuple], $attributes, $touch);
-
-                $changes['attached'][] = $tuple;
-            } elseif (count($attributes) > 0 &&
-                $this->updateExistingPivot($tuple, $attributes, $touch)) {
-                $changes['updated'][] = $tuple;
+                $changes['attached'][] = $record['tuple'];
+            } elseif (count($record['attributes']) > 0 &&
+                $this->updateExistingPivot($current[$key], $record['attributes'], $touch)) {
+                $changes['updated'][] = $record['tuple'];
             }
         }
 
@@ -1114,9 +1182,13 @@ class BelongsToMany extends BaseBelongsToMany
     }
 
     /**
-     * Get the serialized keys of currently attached pivots.
+     * Get the currently attached composite keys, keyed by their canonical
+     * serialized form (see `serializeCompositeKey`) with the raw database
+     * tuple as value. The canonical key makes set operations against the
+     * requested records type-agnostic; the raw tuple is what detach queries
+     * and the `detached` change set report.
      *
-     * @return array
+     * @return array<string, array>
      */
     protected function getCurrentPivotKeys(): array
     {
@@ -1124,9 +1196,15 @@ class BelongsToMany extends BaseBelongsToMany
             $this->qualifyPivotColumn($this->relatedPivotKey)
         );
 
-        return $pivots->map(fn ($record) => json_encode(
-            array_map(fn ($k) => $record->{$k}, $this->relatedPivotKey)
-        ))->all();
+        $current = [];
+
+        foreach ($pivots as $record) {
+            $tuple = array_map(fn ($k) => $record->{$k}, $this->relatedPivotKey);
+
+            $current[$this->serializeCompositeKey($tuple)] = $tuple;
+        }
+
+        return $current;
     }
 
     /**

--- a/src/Database/Query/Builder.php
+++ b/src/Database/Query/Builder.php
@@ -2,6 +2,7 @@
 
 namespace Awobaz\Compoships\Database\Query;
 
+use Awobaz\Compoships\Exceptions\InvalidUsageException;
 use Illuminate\Database\Query\Builder as BaseQueryBuilder;
 use Illuminate\Support\Arr;
 
@@ -15,12 +16,33 @@ class Builder extends BaseQueryBuilder
      * @param string                                                          $boolean
      * @param bool                                                            $not
      *
+     * @throws \Awobaz\Compoships\Exceptions\InvalidUsageException
+     *
      * @return $this
      */
     public function whereIn($column, $values, $boolean = 'and', $not = false)
     {
         // Here we implement custom support for multi-column 'IN'
         if (is_array($column)) {
+            // An empty tuple list would compile to invalid `IN ()` SQL on most
+            // drivers, and a tuple whose arity differs from the column count
+            // would expand into more (or fewer) placeholders than bindings:
+            // silently NULL-filled on SQLite, a hard protocol error elsewhere.
+            if (empty($values)) {
+                return $this->whereRaw($not ? '1 = 1' : '0 = 1', [], $boolean);
+            }
+
+            foreach ($values as $tuple) {
+                if (!is_array($tuple) || count($tuple) !== count($column)) {
+                    throw new InvalidUsageException(sprintf(
+                        'Composite whereIn expects tuples of arity %d (columns: %s), got %s.',
+                        count($column),
+                        implode(', ', $column),
+                        var_export($tuple, true)
+                    ));
+                }
+            }
+
             $inOperator = $not ? 'NOT IN' : 'IN';
             $prefix = $this->getConnection()->getTablePrefix();
 

--- a/tests/Migration.php
+++ b/tests/Migration.php
@@ -156,6 +156,17 @@ class Migration extends BaseMigration
             $table->timestamps();
         });
 
+        // Same shape as project_team but without a surrogate id column, so
+        // pivot update/delete queries must locate rows by the composite keys
+        // alone (the conventional Laravel pivot table layout).
+        Capsule::schema()->create('project_team_no_id', function (Blueprint $table) {
+            $table->string('team_region_code');
+            $table->integer('team_division_id')->unsigned();
+            $table->string('project_region_code');
+            $table->integer('project_division_id')->unsigned();
+            $table->string('role')->nullable();
+        });
+
         // Pivot table for asymmetric belongsToMany tests:
         //   User (scalar PK 'id')  <->  Project (composite key 'region_code, division_id')
         // Used by both User::projects() and Project::users() to verify both

--- a/tests/Models/ProjectTeamNoIdPivot.php
+++ b/tests/Models/ProjectTeamNoIdPivot.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Awobaz\Compoships\Tests\Models;
+
+use Awobaz\Compoships\Database\Eloquent\Relations\Pivot;
+
+class ProjectTeamNoIdPivot extends Pivot
+{
+    protected $table = 'project_team_no_id';
+}

--- a/tests/Models/Team.php
+++ b/tests/Models/Team.php
@@ -49,6 +49,18 @@ class Team extends Model
         )->using(ProjectTeamPivot::class);
     }
 
+    public function projectsWithPivotModelNoId()
+    {
+        return $this->belongsToMany(
+            Project::class,
+            'project_team_no_id',
+            ['team_region_code', 'team_division_id'],
+            ['project_region_code', 'project_division_id'],
+            ['region_code', 'division_id'],
+            ['region_code', 'division_id']
+        )->using(ProjectTeamNoIdPivot::class);
+    }
+
     public function projectsWithEnumPivot()
     {
         return $this->belongsToMany(

--- a/tests/Unit/BelongsToManySyncTypeSafetyTest.php
+++ b/tests/Unit/BelongsToManySyncTypeSafetyTest.php
@@ -1,0 +1,272 @@
+<?php
+
+namespace Awobaz\Compoships\Tests\Unit;
+
+use Awobaz\Compoships\Database\Eloquent\Relations\BelongsToMany;
+use Awobaz\Compoships\Exceptions\InvalidUsageException;
+use Awobaz\Compoships\Tests\Models\Project;
+use Awobaz\Compoships\Tests\Models\Team;
+use Awobaz\Compoships\Tests\TestCase\TestCase;
+use Closure;
+use Illuminate\Database\Capsule\Manager as Capsule;
+
+/**
+ * Regression tests for type-safe composite-key sync()/toggle() comparisons
+ * and arity-checked tuple normalization on the composite whereIn paths.
+ *
+ * @covers \Awobaz\Compoships\Database\Eloquent\Relations\BelongsToMany
+ * @covers \Awobaz\Compoships\Database\Query\Builder
+ */
+class BelongsToManySyncTypeSafetyTest extends TestCase
+{
+    public function test_sync_same_key_with_string_typed_component_updates_in_place()
+    {
+        $team = $this->createTeam('US', 1, 'Alpha');
+        $this->createProject('US', 1, 'Website');
+        $team->projectsWithMeta()->attach([['US', 1]], ['role' => 'old']);
+        $originalPivotId = Capsule::table('project_team')->value('id');
+
+        Capsule::connection()->enableQueryLog();
+        $changes = $team->projectsWithMeta()->sync([json_encode(['US', '1']) => ['role' => 'new']]);
+
+        $this->assertCount(0, $changes['attached']);
+        $this->assertCount(0, $changes['detached']);
+        $this->assertCount(1, $changes['updated']);
+        $this->assertEquals($originalPivotId, Capsule::table('project_team')->value('id'));
+        $this->assertSame('new', Capsule::table('project_team')->value('role'));
+        $this->assertNoBindingMismatch();
+    }
+
+    public function test_sync_same_key_with_custom_pivot_updates_in_place_with_valid_sql()
+    {
+        $team = $this->createTeam('US', 1, 'Alpha');
+        $this->createProject('US', 1, 'Website');
+        $team->projectsWithPivotModel()->attach([['US', 1]], ['role' => 'old']);
+        $originalPivotId = Capsule::table('project_team')->value('id');
+
+        Capsule::connection()->enableQueryLog();
+        $changes = $team->projectsWithPivotModel()->sync([json_encode(['US', 1]) => ['role' => 'new']]);
+
+        $this->assertCount(0, $changes['attached']);
+        $this->assertCount(0, $changes['detached']);
+        $this->assertCount(1, $changes['updated']);
+        $this->assertEquals($originalPivotId, Capsule::table('project_team')->value('id'));
+        $this->assertSame('new', Capsule::table('project_team')->value('role'));
+        $this->assertNoBindingMismatch();
+    }
+
+    public function test_sync_same_key_with_string_typed_component_on_custom_pivot_updates_in_place()
+    {
+        $team = $this->createTeam('US', 1, 'Alpha');
+        $this->createProject('US', 1, 'Website');
+        $team->projectsWithPivotModel()->attach([['US', 1]], ['role' => 'old']);
+        $originalPivotId = Capsule::table('project_team')->value('id');
+
+        Capsule::connection()->enableQueryLog();
+        $changes = $team->projectsWithPivotModel()->sync([json_encode(['US', '1']) => ['role' => 'new']]);
+
+        $this->assertCount(0, $changes['attached']);
+        $this->assertCount(0, $changes['detached']);
+        $this->assertCount(1, $changes['updated']);
+        $this->assertEquals($originalPivotId, Capsule::table('project_team')->value('id'));
+        $this->assertSame('new', Capsule::table('project_team')->value('role'));
+        $this->assertNoBindingMismatch();
+    }
+
+    public function test_sync_matches_pre_encoded_json_keys_regardless_of_formatting()
+    {
+        $team = $this->createTeam('US', 1, 'Alpha');
+        $this->createProject('US', 1, 'Website');
+        $team->projectsWithMeta()->attach([['US', 1]], ['role' => 'old']);
+
+        $keyVariants = [
+            '["US",1]'   => 'first',
+            '["US", 1]'  => 'second',
+            '["US","1"]' => 'third',
+        ];
+
+        foreach ($keyVariants as $key => $role) {
+            $changes = $team->projectsWithMeta()->sync([$key => ['role' => $role]]);
+
+            $this->assertCount(0, $changes['attached'], 'Key variant '.$key.' was not matched');
+            $this->assertCount(0, $changes['detached'], 'Key variant '.$key.' caused a detach');
+            $this->assertCount(1, $changes['updated'], 'Key variant '.$key.' did not update');
+            $this->assertSame($role, Capsule::table('project_team')->value('role'));
+            $this->assertSame(1, Capsule::table('project_team')->count());
+        }
+    }
+
+    public function test_sync_updates_existing_and_attaches_new()
+    {
+        $team = $this->createTeam('US', 1, 'Alpha');
+        $this->createProject('US', 1, 'Website');
+        $this->createProject('EU', 2, 'API');
+        $team->projectsWithMeta()->attach([['US', 1]], ['role' => 'old']);
+
+        $changes = $team->projectsWithMeta()->sync([
+            json_encode(['US', '1']) => ['role' => 'new'],
+            ['EU', 2],
+        ]);
+
+        $this->assertCount(1, $changes['attached']);
+        $this->assertCount(0, $changes['detached']);
+        $this->assertCount(1, $changes['updated']);
+        $this->assertSame(2, Capsule::table('project_team')->count());
+    }
+
+    public function test_sync_empty_detaches_all_on_custom_pivot_relation()
+    {
+        $team = $this->createTeam('US', 1, 'Alpha');
+        $this->createProject('US', 1, 'Website');
+        $this->createProject('EU', 2, 'API');
+        $team->projectsWithPivotModel()->attach([['US', 1], ['EU', 2]]);
+
+        Capsule::connection()->enableQueryLog();
+        $changes = $team->projectsWithPivotModel()->sync([]);
+
+        $this->assertCount(2, $changes['detached']);
+        $this->assertSame(0, Capsule::table('project_team')->count());
+        $this->assertNoBindingMismatch();
+    }
+
+    public function test_toggle_with_string_typed_component_detaches_existing_row()
+    {
+        $team = $this->createTeam('US', 1, 'Alpha');
+        $this->createProject('US', 1, 'Website');
+        $team->projects()->attach([['US', 1]]);
+
+        $changes = $team->projects()->toggle([['US', '1']]);
+
+        $this->assertCount(0, $changes['attached']);
+        $this->assertCount(1, $changes['detached']);
+        $this->assertSame(0, Capsule::table('project_team')->count());
+    }
+
+    public function test_changes_arrays_preserve_value_types()
+    {
+        $team = $this->createTeam('US', 1, 'Alpha');
+        $this->createProject('US', 1, 'Website');
+        $this->createProject('EU', 2, 'API');
+        $team->projects()->attach([['US', 1]]);
+
+        $changes = $team->projects()->sync([['EU', 2]]);
+
+        $this->assertSame([['EU', 2]], $changes['attached']);
+        $this->assertSame([['US', 1]], $changes['detached']);
+    }
+
+    public function test_detach_with_wrong_arity_tuple_throws_before_any_sql()
+    {
+        $team = $this->createTeam('US', 1, 'Alpha');
+        $this->createProject('US', 1, 'Website');
+        $team->projects()->attach([['US', 1]]);
+
+        Capsule::connection()->enableQueryLog();
+
+        try {
+            $team->projects()->detach([['US']]);
+            $this->fail('Expected InvalidUsageException for wrong-arity tuple');
+        } catch (InvalidUsageException $exception) {
+            $this->assertStringContainsString('arity', $exception->getMessage());
+        }
+
+        $this->assertSame([], Capsule::connection()->getQueryLog());
+        $this->assertSame(1, Capsule::table('project_team')->count());
+    }
+
+    public function test_detach_with_scalar_id_on_custom_pivot_relation_throws_before_any_sql()
+    {
+        $team = $this->createTeam('US', 1, 'Alpha');
+        $this->createProject('US', 1, 'Website');
+        $team->projectsWithPivotModel()->attach([['US', 1]]);
+
+        Capsule::connection()->enableQueryLog();
+
+        try {
+            $team->projectsWithPivotModel()->detach('US');
+            $this->fail('Expected InvalidUsageException for scalar id on composite relation');
+        } catch (InvalidUsageException $exception) {
+            $this->assertStringContainsString('arity', $exception->getMessage());
+        }
+
+        $this->assertSame([], Capsule::connection()->getQueryLog());
+        $this->assertSame(1, Capsule::table('project_team')->count());
+    }
+
+    public function test_detach_with_empty_array_is_a_noop_on_custom_pivot_relation()
+    {
+        $team = $this->createTeam('US', 1, 'Alpha');
+        $this->createProject('US', 1, 'Website');
+        $team->projectsWithPivotModel()->attach([['US', 1]]);
+
+        $result = $team->projectsWithPivotModel()->detach([]);
+
+        $this->assertSame(0, $result);
+        $this->assertSame(1, Capsule::table('project_team')->count());
+    }
+
+    public function test_composite_where_in_with_empty_values_matches_nothing()
+    {
+        $team = $this->createTeam('US', 1, 'Alpha');
+        $this->createProject('US', 1, 'Website');
+        $team->projects()->attach([['US', 1]]);
+
+        $query = Team::query()->getQuery()->from('project_team')->whereIn(
+            ['project_region_code', 'project_division_id'],
+            []
+        );
+
+        $this->assertStringContainsString('0 = 1', $query->toSql());
+        $this->assertCount(0, $query->get());
+    }
+
+    public function test_composite_where_in_with_wrong_arity_tuple_throws()
+    {
+        $this->expectException(InvalidUsageException::class);
+
+        Team::query()->getQuery()->from('project_team')->whereIn(
+            ['project_region_code', 'project_division_id'],
+            [['US']]
+        );
+    }
+
+    public function test_canonical_key_normalizes_scalar_types_and_preserves_null()
+    {
+        $relation = $this->createTeam('US', 1, 'Alpha')->projects();
+        $serialize = Closure::bind(function (array $tuple) {
+            return $this->serializeCompositeKey($tuple);
+        }, $relation, BelongsToMany::class);
+
+        $this->assertSame($serialize(['US', 1]), $serialize(['US', '1']));
+        $this->assertNotSame($serialize(['US', null]), $serialize(['US', '']));
+    }
+
+    protected function createTeam(string $regionCode, int $divisionId, string $name): Team
+    {
+        return Team::create([
+            'region_code' => $regionCode,
+            'division_id' => $divisionId,
+            'name'        => $name,
+        ]);
+    }
+
+    protected function createProject(string $regionCode, int $divisionId, string $name): Project
+    {
+        return Project::create([
+            'region_code' => $regionCode,
+            'division_id' => $divisionId,
+            'name'        => $name,
+        ]);
+    }
+
+    protected function assertNoBindingMismatch(): void
+    {
+        foreach (Capsule::connection()->getQueryLog() as $query) {
+            $this->assertSame(
+                substr_count($query['query'], '?'),
+                count($query['bindings']),
+                'Placeholder/binding count mismatch in: '.$query['query']
+            );
+        }
+    }
+}

--- a/tests/Unit/BelongsToManySyncTypeSafetyTest.php
+++ b/tests/Unit/BelongsToManySyncTypeSafetyTest.php
@@ -230,6 +230,42 @@ class BelongsToManySyncTypeSafetyTest extends TestCase
         );
     }
 
+    public function test_sync_update_targets_row_by_composite_key_on_pivot_table_without_surrogate_id()
+    {
+        $team = $this->createTeam('US', 1, 'Alpha');
+        $this->createProject('US', 1, 'Website');
+        $this->createProject('EU', 2, 'API');
+        $team->projectsWithPivotModelNoId()->attach([['US', 1], ['EU', 2]], ['role' => 'old']);
+
+        Capsule::connection()->enableQueryLog();
+        $changes = $team->projectsWithPivotModelNoId()->sync([
+            json_encode(['US', '1']) => ['role' => 'new'],
+            ['EU', 2],
+        ]);
+
+        $this->assertCount(0, $changes['attached']);
+        $this->assertCount(0, $changes['detached']);
+        $this->assertCount(1, $changes['updated']);
+        $this->assertSame('new', Capsule::table('project_team_no_id')->where('project_region_code', 'US')->value('role'));
+        $this->assertSame('old', Capsule::table('project_team_no_id')->where('project_region_code', 'EU')->value('role'));
+        $this->assertSame(2, Capsule::table('project_team_no_id')->count());
+        $this->assertNoBindingMismatch();
+    }
+
+    public function test_detach_deletes_row_by_composite_key_on_pivot_table_without_surrogate_id()
+    {
+        $team = $this->createTeam('US', 1, 'Alpha');
+        $this->createProject('US', 1, 'Website');
+        $this->createProject('EU', 2, 'API');
+        $team->projectsWithPivotModelNoId()->attach([['US', 1], ['EU', 2]]);
+
+        $result = $team->projectsWithPivotModelNoId()->detach([['US', 1]]);
+
+        $this->assertSame(1, $result);
+        $this->assertSame(1, Capsule::table('project_team_no_id')->count());
+        $this->assertSame('EU', Capsule::table('project_team_no_id')->value('project_region_code'));
+    }
+
     public function test_canonical_key_normalizes_scalar_types_and_preserves_null()
     {
         $relation = $this->createTeam('US', 1, 'Alpha')->projects();


### PR DESCRIPTION
Fixes two defects in the composite-key `belongsToMany` mutation paths, both reproduced against 3.0.2.

## Problem

**1. Type-sensitive tuple comparison in `sync()` / `toggle()`**

"Currently attached" and "requested" keys were compared via `json_encode` of raw values. The two sides come from different sources (driver results vs. caller input), so when scalar types diverge (an integer key column read back as a string by the driver, or a caller supplying `'1'` for a stored `1`), equal-by-value tuples serialize to different strings. `sync()` then detaches and re-attaches the row instead of updating it in place (the pivot row is replaced: surrogate id and timestamps reset, delete/insert instead of update), and `toggle()` attaches a duplicate row instead of detaching the existing one.

**2. Placeholder/binding mismatch on the custom-pivot update path**

`getCurrentlyAttachedPivotsForIds()` passed `$ids` through bare `parseIds()` with no tuple-shape normalization. On Laravel 12/13, `updateExistingPivotUsingCustomClass()` passes a single flat tuple, which `parseIds()` misreads as a list of scalar ids, so the composite `whereIn` emits more placeholders than bindings:

```
SQLSTATE[08P01]: bind message supplies 4 parameters, but prepared statement requires 6
SQL: select * from "pivot" where "a" = ? and "b" = ? and (c, d) IN ((?, ?), (?, ?))
```

PostgreSQL fails hard; SQLite silently treats unbound placeholders as NULL, which is why the test suite never caught it. Trigger: a same-key `sync()` carrying pivot attributes on a relation configured with `->using(...)` when the parent already has matching rows attached.

## Fix

- One canonical serializer (`serializeCompositeKey()`) produces the comparison key for both sides: backed enums resolved to their backing scalar, non-null components cast to string, null preserved as JSON null so it can never collide with an empty string. Normalization is representational only: `normalizeRecordKeys()` and `getCurrentPivotKeys()` carry the original tuples alongside the canonical keys, so attach payloads and the `sync()`/`toggle()` change arrays keep caller-supplied values (`attached`/`updated`) and database-read values (`detached`).
- Pre-encoded JSON string keys are decoded and re-encoded canonically, so key formatting (whitespace) and component typing cannot defeat matching.
- A shared arity-validated normalizer (`normalizeTupleList()`) now feeds all three composite `whereIn` call sites: `detach()`, `newPivotStatementForId()`, and `getCurrentlyAttachedPivotsForIds()`. Wrong-arity tuples throw `InvalidUsageException` naming the tuple, the expected arity, and the `relatedPivotKey` columns before any SQL executes. Empty tuple sets short-circuit to no-ops.
- The composite branch of `Builder::whereIn()` compiles an empty tuple list to `0 = 1` (matching Laravel's empty `whereIn` semantics, instead of invalid `IN ()`) and rejects wrong-arity tuples, as a last line of defense for callers that bypass the relation layer.

## Behavior change

A `sync()` whose key equals an already-attached tuple now performs an in-place pivot update instead of a detach + re-attach. Suggested changelog entry under "Fixed".

## Coverage

16 regression tests in `tests/Unit/BelongsToManySyncTypeSafetyTest.php`, written failing-first against the current code, including the exact 4-binds-vs-6-placeholders signature above. Every mutation test asserts placeholder-vs-binding counts on the executed queries (row assertions alone cannot catch this class on SQLite), and a new `project_team_no_id` fixture proves custom-pivot update/delete locate rows by the composite keys alone on pivot tables without a surrogate id. Full suite: 202 tests, 643 assertions passing.
