### PR TITLE
Enhance whereColumn to handle '=' operator short-cut

### DIFF
--- a/src/Database/Query/Builder.php
+++ b/src/Database/Query/Builder.php
@@ -82,6 +82,13 @@ class Builder extends BaseQueryBuilder
 
     public function whereColumn($first, $operator = null, $second = null, $boolean = 'and')
     {
+        // If the given operator is not found in the list of valid operators we will
+        // assume that the developer is just short-cutting the '=' operators and
+        // we will set the operators to '=' and set the values appropriately.
+        if ($this->invalidOperator($operator)) {
+            [$second, $operator] = [$operator, '='];
+        }
+
         // If the column and values are arrays, we will assume it is a multi-columns relationship
         // and we adjust the 'where' clauses accordingly
         if (is_array($first) && is_array($second)) {


### PR DESCRIPTION
[Illuminate/Database/Query/Builder.php#L1181-L1186](https://github.com/laravel/framework/blob/90d01e88d6fac29e2a8d1319fd6eea106ded385e/src/Illuminate/Database/Query/Builder.php#L1181-L1186)
>If the given operator is not found in the list of valid operators we will
assume that the developer is just short-cutting the '=' operators

**Before:**
```php
->whereColumn(['user_id', 'team_id'], '=', ['users.id', 'users.team_id'])
```

**After:**
```php
->whereColumn(['user_id', 'team_id'], ['users.id', 'users.team_id'])
```