### PR TITLE
Fallback to old OR/AND clauses on whereIn when no tuple syntax support

### DIFF
--- a/src/Database/Query/Builder.php
+++ b/src/Database/Query/Builder.php
@@ -55,7 +55,10 @@ class Builder extends BaseQueryBuilder
                 }
             }
 
-            if (!in_array($connection->getDriverName(), ['sqlite', 'mysql', 'mariadb', 'pgsql'])) {
+            if (
+                !in_array($connection->getDriverName(), ['sqlite', 'mysql', 'mariadb', 'pgsql']) ||
+                    Arr::some($values, fn ($value) => in_array(null, $value, true))
+            ) {
                 // use a series of OR/AND clauses when optimized row value expressions can't be used
                 return $this->where(function ($query) use ($column, $values) {
                     foreach ($values as $value) {

--- a/src/Database/Query/Builder.php
+++ b/src/Database/Query/Builder.php
@@ -45,8 +45,9 @@ class Builder extends BaseQueryBuilder
             }
 
             $inOperator = $not ? 'NOT IN' : 'IN';
-            $prefix = $this->getConnection()->getTablePrefix();
-            $grammar = $this->getConnection()->getQueryGrammar();
+            $connection = $this->getConnection();
+            $prefix = $connection->getTablePrefix();
+            $grammar = $connection->getQueryGrammar();
 
             foreach ($column as &$value) {
                 if (!$grammar->isExpression($value) && !Str::contains($value, '.')) {
@@ -54,15 +55,17 @@ class Builder extends BaseQueryBuilder
                 }
             }
 
-            if ($this->getConnection()->getDriverName() === 'sqlsrv') {
-                foreach ($column as $column_number => $column_name) {
-                    $column_values = array_unique(Arr::pluck($values, $column_number));
-                    $values_placeholders = implode(', ', array_fill(0, count($column_values), '?'));
-
-                    $this->whereRaw("{$column_name} {$inOperator} ({$values_placeholders})", Arr::flatten($column_values), $boolean);
-                }
-
-                return $this;
+            if (!in_array($connection->getDriverName(), ['sqlite', 'mysql', 'mariadb', 'pgsql'])) {
+                // use a series of OR/AND clauses when optimized row value expressions can't be used
+                return $this->where(function ($query) use ($column, $values) {
+                    foreach ($values as $value) {
+                        $query->orWhere(function ($query) use ($column, $value) {
+                            foreach ($column as $index => $aColumn) {
+                                $query->where($aColumn, $value[$index]);
+                            }
+                        });
+                    }
+                });
             }
 
             $columns = implode(', ', array_map(
@@ -72,9 +75,7 @@ class Builder extends BaseQueryBuilder
             $tuplePlaceholders = '('.implode(', ', array_fill(0, count($column), '?')).')';
             $placeholderList = implode(', ', array_fill(0, count($values), $tuplePlaceholders));
 
-            $this->whereRaw("({$columns}) {$inOperator} ({$placeholderList})", Arr::flatten($values), $boolean);
-
-            return $this;
+            return $this->whereRaw("({$columns}) {$inOperator} ({$placeholderList})", Arr::flatten($values), $boolean);
         }
 
         return parent::whereIn($column, $values, $boolean, $not);

--- a/src/Database/Query/Builder.php
+++ b/src/Database/Query/Builder.php
@@ -44,7 +44,6 @@ class Builder extends BaseQueryBuilder
                 }
             }
 
-            $inOperator = $not ? 'NOT IN' : 'IN';
             $connection = $this->getConnection();
             $prefix = $connection->getTablePrefix();
             $grammar = $connection->getQueryGrammar();
@@ -68,9 +67,10 @@ class Builder extends BaseQueryBuilder
                             }
                         });
                     }
-                });
+                }, null, null, $boolean.($not ? ' not' : ''));
             }
 
+            $inOperator = $not ? 'NOT IN' : 'IN';
             $columns = implode(', ', array_map(
                 fn ($v) => $grammar->isExpression($v) ? $v->getValue($grammar) : $grammar->wrap($v),
                 $column

--- a/tests/Unit/BuilderTest.php
+++ b/tests/Unit/BuilderTest.php
@@ -54,4 +54,29 @@ class BuilderTest extends TestCase
         $this->assertCount(1, $allocations);
         $this->assertCount(2, $allocations[0]->originalPackages);
     }
+
+    public function test_wherein_uses_fallback_when_null_values()
+    {
+        $allocationId1 = Capsule::table('allocations')->insertGetId([
+            'user_id'    => 1,
+            'booking_id' => 1,
+        ]);
+        $allocationId2 = Capsule::table('allocations')->insertGetId([
+            'user_id'    => 2,
+            'booking_id' => null,
+        ]);
+        $allocation1 = Allocation::find($allocationId1);
+        $allocation2 = Allocation::find($allocationId2);
+
+        $query1 = Allocation::query()->getRelation('user');
+        $query1->addEagerConstraints([$allocation1]);
+        $sql1 = $query1->toRawSql();
+
+        $query2 = Allocation::query()->getRelation('user');
+        $query2->addEagerConstraints([$allocation2]);
+        $sql2 = $query2->toRawSql();
+
+        $this->assertEquals('select * from "users" where ("users"."id", "users"."booking_id") IN ((1, 1))', $sql1);
+        $this->assertEquals('select * from "users" where (("users"."id" = 2 and "users"."booking_id" is null))', $sql2);
+    }
 }


### PR DESCRIPTION
**Bugs on #204** (_Compound keys break when used with SQL Server, it does not support compound WHERE IN._), 

That PR attempted to restore support for the `sqlsrv` driver, but it would be better to apply tuples only to drivers known to support them; if a driver lacks support, it would simply use the fallback.

**Why fallback to the old syntax** (before #192 tuples)**?**

becouse `AND`/`OR` approach was proven, and the solution for multiple `whereIn` clauses introduced a new bug.

I describe the problem in the comment https://github.com/topclaudy/compoships/pull/204#issuecomment-4692420689:

> Let's assume a hasMany
> 
> ```php
> allocation 1 = [
>     'booking_id' => 1,
>     'vehicle_id' => 1,
> ]
> allocation 2 = [
>     'booking_id' => 2,
>     'vehicle_id' => 2,
> ]
> allocation 3 to 1000 = [
>     'booking_id' => 1,
>     'vehicle_id' => 2,
> ]
> allocation 1001 to 2000 = [
>     'booking_id' => 2,
>     'vehicle_id' => 1,
> ]
> 
> tracking_tasks 1 = [
>     'booking_id' => 1,
>     'vehicle_id' => 1,
> ]
> tracking_tasks 2 = [
>     'booking_id' => 2,
>     'vehicle_id' => 2,
> ]
> ```
> 
> Now
> 
> ```php
> // hasMany(Allocation::class, ['booking_id', 'vehicle_id'], ['booking_id', 'vehicle_id']);
> TrackingTasks::with('allocations')->get(); 
> ```
> 
> give you (eager loading query)
> 
> ```sql
> select * from "allocations" where 
> /* here */
> "allocations"."booking_id" IN (1, 2) and
> "allocations"."vehicle_id" IN (1, 2)
> ```
> 
> So, tuple (1,2)/(2,1) would be within the result adding 1000+ records that will not be used Bug [2.5.3+](https://github.com/topclaudy/compoships/releases/tag/2.5.3)

---

**UPDATE:**

Tuples do not work correctly when `NULL` values ​​are present; use the fallback in that case too.
- Closes #197, Alternative to #199
>Version 2.5.0 changed the `whereIn()`  implementation for composite keys from
using OR/WHERE clauses to tuple syntax. This breaks queries when NULL values
are involved because SQL tuple comparisons don't handle NULL correctly.
>
>Example:
>
>New (2.5.x): `(col1, col2, col3) IN ((1, 2, NULL))` → returns 0 rows (broken)
Old (2.4.x): `col1 = 1 AND col2 = 2 AND col3 IS NULL` → returns correct rows (works)
Affected: All composite key relationships with nullable columns

---

**UPDATE 2:**

Old `AND`/`OR` approach does not take into account the `$boolean` and the `$not` condition.
`orWhereIn`, `orWhereNotIn`, `whereNotIn` now supported
[Illuminate/Database/Query/Builder.php#L1147](https://github.com/laravel/framework/blob/90d01e88d6fac29e2a8d1319fd6eea106ded385e/src/Illuminate/Database/Query/Builder.php#L1147)